### PR TITLE
Add inheritance support

### DIFF
--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -23,7 +23,18 @@ class UserWithoutScopes < ActiveRecord::Base
   bitfield :bits, 1 => :seller, 2 => :insane, 4 => :stupid, :scopes => false
 end
 
+class UserWithoutSetBitfield < ActiveRecord::Base
+  set_table_name 'users'
+  include Bitfields
+end
+
 class InheritedUser < User
+end
+
+class GrandchildInheritedUser < InheritedUser
+end
+
+class InheritedUserWithoutSetBitfield < UserWithoutSetBitfield
 end
 
 class OverwrittenUser < User
@@ -66,7 +77,6 @@ class InitializedUser < User
     self.insane = false
   end
 end
-
 
 describe Bitfields do
   before do
@@ -364,9 +374,23 @@ describe Bitfields do
     end
 
     it "knows inherited values without overwriting" do
-      pending do
-        InheritedUser.bitfield_column(:seller).should == :bits
-      end
+      InheritedUser.bitfield_column(:seller).should == :bits
+    end
+
+    it "has inherited scopes" do
+      InheritedUser.should respond_to(:not_seller)
+    end
+
+    it "has inherited methods" do
+      InheritedUser.new.should respond_to(:seller?)
+    end
+
+    it "knows grandchild inherited values without overwriting" do
+      GrandchildInheritedUser.bitfield_column(:seller).should == :bits
+    end
+
+    it "inherits no bitfields for a user without bitfields set" do
+      InheritedUserWithoutSetBitfield.bitfields.should be_nil
     end
   end
 


### PR DESCRIPTION
Hello, working on behalf of LumosLabs and we're using your bitfield library but noticed the inheritance didn't seem to be working with the attr_accesor so I figured I might as well just go into the library and fix it the right way rather than monkey patching :P

Let me know if you have any questions, below are the commit notes but you can find them in the commit message as well:
- Add in bitfield_original_args to store an array of all the args bitfield was called with for the class
- Extract the code which sets the :bitfields and :bitfield_options values out of the code that sets scopes, etc since scopes, etc inherit without problem
- Add in an inherited block to the class to trigger adding and populating the attr_accessors via bitfield_original_options
- Add in a few extra specs to cover inheritance situations
