### PR TITLE
32 bit CPU support

### DIFF
--- a/lib/bitfields.rb
+++ b/lib/bitfields.rb
@@ -29,7 +29,7 @@ module Bitfields
 
   def self.extract_bits(options)
     bitfields = {}
-    options.keys.select{|key| key.is_a?(Fixnum) }.each do |bit|
+    options.keys.select{|key| key.is_a?(Fixnum) || key.is_a?(Bignum) }.each do |bit|
       raise "#{bit} is not a power of 2 !!" unless bit.to_s(2).scan('1').size == 1
       bit_name = options.delete(bit).to_sym
       raise DuplicateBitNameError if bitfields.include?(bit_name)


### PR DESCRIPTION
I'v found that on 32 bit servers(which still popular) bitfields limited because  extract_bits methods filter only Fixnum which ok for 64 bit but not enough for 32 bit.