### PR TITLE
Test for power of two with bit trick

### DIFF
--- a/lib/bitfields.rb
+++ b/lib/bitfields.rb
@@ -30,7 +30,7 @@ module Bitfields
   def self.extract_bits(options)
     bitfields = {}
     options.keys.select{|key| key.is_a?(Numeric) }.each do |bit|
-      raise "#{bit} is not a power of 2 !!" unless bit.to_s(2).scan('1').size == 1
+      raise "#{bit} is not a power of 2 !!" unless bit & (bit - 1) == 0
       bit_name = options.delete(bit).to_sym
       raise DuplicateBitNameError if bitfields.include?(bit_name)
       bitfields[bit_name] = bit

--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -299,6 +299,20 @@ describe Bitfields do
         end
       }.should raise_error(Bitfields::DuplicateBitNameError)
     end
+
+    it "checks that bitfields are powers of two" do
+      lambda{
+        CheckRaise.class_eval do
+          bitfield :foo, 1 => :bar, 3 => :baz, 4 => :bar
+        end
+      }.should raise_error("3 is not a power of 2 !!")
+
+      lambda{
+        CheckRaise.class_eval do
+          bitfield :foo, 1 => :bar, -1 => :baz, 4 => :bar
+        end
+      }.should raise_error("-1 is not a power of 2 !!")
+    end
   end
 
   describe :set_bitfield_sql do


### PR DESCRIPTION
hey there, it occurred to me while reading this code that there is probably a neat bit trick for testing if an integer is a power of two. sure enough, i opened up Hacker's Delight and found this gem.

for fun i thought i'd benchmark this implementation against the bit trick

```ruby
require 'benchmark'

def bit_test_string(bit)
  bit.to_s(2).scan('1').size == 1
end

def bit_test(bit)
  bit & (bit - 1) == 0
end

array = (1..1_000_000).map { rand(64) }

Benchmark.bmbm do |x|
  x.report("bit_test") { array.each { |e| bit_test(e) } }
  x.report("bit_test_string") { array.each { |e| bit_test_string(e) } }
end
```

the results
```
artemisia:seako seako$ ruby bit_twiddling.rb 
Rehearsal ---------------------------------------------------
bit_test          0.100000   0.000000   0.100000 (  0.103825)
bit_test_string   2.170000   0.010000   2.180000 (  2.183716)
------------------------------------------ total: 2.280000sec

                      user     system      total        real
bit_test          0.090000   0.000000   0.090000 (  0.101036)
bit_test_string   2.180000   0.000000   2.180000 (  2.187297)
```
which isn't too shabby.

it wasn't until i decided to write a test for raising an exception if the user tries to create a bitfield with a value that isn't a power of two that i realized that this implementation has an additional virtue which is that it also catches an error case the existing implementation does not. the case it catches is if the user tries to use a negative number as the key for a bit field. i highly doubt that anyone would ever try to do that in practice but, in case they did, the existing implementation would convert, for example, `-4` to `'-100'`, find only one '1', and not raise an exception. whereas, this implementation would find that `-4 & (-5) != 0` and raise an exception.

anyway,
for your consideration