### PR TITLE
Added example to document bitfield_values method

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,6 +51,13 @@ Delete the shop when a user is no longer a seller
 before_save :delete_shop, if: -> { |u| u.seller_change == [true, false]}
 ```
 
+List fields and their respective values
+
+```ruby
+user = User.new(insane: true)
+user.bitfield_values(:my_bits) == { seller: false, insane: true, stupid: false } 
+```
+
 TIPS
 ====
  - [Upgrading] in version 0.2.2 the first field(when not given as hash) used bit 2 -> add a bogus field in first position


### PR DESCRIPTION
Hey :wave: 

First of all thank you for writing this gem and maintaining it :heart: 

This PR adds an example in the README to document the public bitfield_values instance method. 

I find myself often looking for this method and always end up reading through the source to find the exact naming. So I thought I'd add an example of it's usage for others (and for myself when I forget again :wink: )

Hope this is all ok, thanks
.FxN