### PR TITLE
Add option to disable autogenerating methods per bitfield-name..

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,7 @@ user.my_bits # => 3
 ```
 
  - records bitfield_changes `user.bitfield_changes # => {"seller" => [false, true], "insane" => [false, true]}` (also `seller_was` / `seller_change` / `seller_changed?` / `seller_became_true?`)
+   - Individual added methods (i.e, `seller_was`, `seller_changed?`, etc..) can be deactivated with `bitfield ..., added_instance_methods: false`
  - adds scopes `User.seller.sensible.first` (deactivate with `bitfield ..., scopes: false`)
  - builds sql `User.bitfield_sql(insane: true, sensible: false) # => '(users.my_bits & 6) = 1'`
  - builds index-using sql with `bitfield ... , query_mode: :in_list` and `User.bitfield_sql(insane: true, sensible: false) # => 'users.my_bits IN (2, 3)'` (2 and 1+2) often slower than :bit_operator sql especially for high number of bits

--- a/lib/bitfields.rb
+++ b/lib/bitfields.rb
@@ -81,18 +81,20 @@ module Bitfields
 
     def add_bitfield_methods(column, options)
       bitfields[column].keys.each do |bit_name|
-        define_method(bit_name) { bitfield_value(bit_name) }
-        define_method("#{bit_name}?") { bitfield_value(bit_name) }
-        define_method("#{bit_name}=") { |value| set_bitfield_value(bit_name, value) }
-        define_method("#{bit_name}_was") { bitfield_value_was(bit_name) }
-        define_method("#{bit_name}_changed?") { bitfield_value_was(bit_name) != bitfield_value(bit_name) }
-        define_method("#{bit_name}_change") do
-          values = [bitfield_value_was(bit_name), bitfield_value(bit_name)]
-          values unless values[0] == values[1]
-        end
-        define_method("#{bit_name}_became_true?") do
-          value = bitfield_value(bit_name)
-          value && bitfield_value_was(bit_name) != value
+        if options[:added_instance_methods] != false
+          define_method(bit_name) { bitfield_value(bit_name) }
+          define_method("#{bit_name}?") { bitfield_value(bit_name) }
+          define_method("#{bit_name}=") { |value| set_bitfield_value(bit_name, value) }
+          define_method("#{bit_name}_was") { bitfield_value_was(bit_name) }
+          define_method("#{bit_name}_changed?") { bitfield_value_was(bit_name) != bitfield_value(bit_name) }
+          define_method("#{bit_name}_change") do
+            values = [bitfield_value_was(bit_name), bitfield_value(bit_name)]
+            values unless values[0] == values[1]
+          end
+          define_method("#{bit_name}_became_true?") do
+            value = bitfield_value(bit_name)
+            value && bitfield_value_was(bit_name) != value
+          end
         end
 
         if options[:scopes] != false

--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -10,6 +10,12 @@ class UserWithBitfieldOptions < ActiveRecord::Base
   bitfield :bits, 1 => :seller, 2 => :insane, 4 => :stupid, :scopes => false
 end
 
+class UserWithInstanceOptions < ActiveRecord::Base
+  self.table_name = 'users'
+  include Bitfields
+  bitfield :bits, 1 => :seller, 2 => :insane, 4 => :stupid, :added_instance_methods => false
+end
+
 class MultiBitUser < ActiveRecord::Base
   self.table_name = 'users'
   include Bitfields
@@ -103,6 +109,7 @@ describe Bitfields do
 
     it "parses them correctly when set" do
       UserWithBitfieldOptions.bitfield_options.should == {:bits => {:scopes => false}}
+      UserWithInstanceOptions.bitfield_options.should == {:bits => {:added_instance_methods => false}}
     end
   end
 
@@ -218,6 +225,20 @@ describe Bitfields do
       user.seller_became_true?.should == false
       user.seller = true
       user.seller_became_true?.should == false
+    end
+
+    context "when :added_instance_methods is false" do
+      %i{
+        seller seller? seller= seller_was seller_changed? seller_change seller_became_true?
+      }.each do |meth|
+        describe "method #{meth} is not generated" do
+          UserWithInstanceOptions.new.respond_to?(meth).should == false
+        end
+      end
+    end
+
+    it "does still have the main bitfield method" do
+      UserWithInstanceOptions.new.bits.should eq 0
     end
   end
 


### PR DESCRIPTION
If you have a bitfield with 50 options, this will save 350 methods from being created.
Great if you're never using them!