### PR TITLE
Let duplicate values work for different bitfields

### DIFF
--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -139,7 +139,7 @@ describe Bitfields do
         user = DuplicateBitUser.new
         user.bitfield_values(:bits).should == {:foo=>false, :bar=>false, :biz=>false}
         user.bitfield_values(:more_bits).should == {:foo=>false, :bar=>false, :biz=>false}
-        user.update bits: 15
+        user.bits = 15
         user.bitfield_values(:bits).should == {:foo=>true, :bar=>true, :biz=>true}
         user.bitfield_values(:more_bits).should == {:foo=>false, :bar=>false, :biz=>false}
       end


### PR DESCRIPTION
Ref #21 

Given a user like this: 

```ruby
class User < ActiveRecord::Base
  include Bitfields
  bitfield :some_bits, 1 => :foo, 2 => :bar
  bitfield :more_bits, 1 => :foo, 2 => :bar
```

Currently, there's some surprising results

```ruby
u = User.new
u.some_bits = 0
u.more_bits = 3
u.bitfield_values(:more_bits)
=> {foo: false, bar: false}
```

This PR works at making it so that two bitfields can have the same value, but probably  isn't ready to merge as-is, but wanted to get thoughts on the direction before going further...

Changes needed for duplicate-values-are-okay:
- Easy (no API changes):
  - [x] By passing the `column_name:` around between some of the private methods, it's easy to make `#bitfield_values` work as one would expect without any API changes.
  - [ ] `#bitfield_changes` could be made to work by changing the logic a bit; instead of getting a flat map of all the values, could change it to use both the column+value, and pass the `column_name` `#bitfield_value_was` for a similar API-less change; will add this to the PR if you like the direction
- Not easy (API changes, or partial functionality) 
  - [ ] Scopes (`User.foo`) wouldn't work...
     - Could add a convoluted API - `User.some_bits_foo` ? `User.foo(:some_bits)` ?
     - Or just add documentation that duplicate values means no scopes for you
  - [ ] Auto generated methods (`user.foo?`) wouldn't work...
     - Could add a convoluted API - `user.some_bits_foo?` ? `user.foo?(:some_bits)` ?
     - Or just add documentation that duplicate values means no autogenerated methods for you
  - [ ] `.bitfield_sql` - `User.bitfield_sql(some_bits: true)` wouldn't work
     - Could add more complex API -> `User.bitfield_sql(foo: {some_bits: true})` ?
     - Or just note that `.bitfield_sql` doesn't work with duplicate values...
  - [ ] `.set_bitfield_sql` - same idea as `.bitfield_sql`

Anyways, love to hear your thoughts, and the path you'd like to move forward on...
- Add a warning if duplicate values are found, saying "nope, can't do that."
- Add partial functionally for duplicate values
- Modify API for full duplicate-values-support
  - But try to retain old API for cases where there are no duplicates?


