### PR TITLE
Bugfix: Initialize Bitfields with Correct Attribute Value

### DIFF
--- a/gemfiles/activerecord_5.1.gemfile.lock
+++ b/gemfiles/activerecord_5.1.gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: ..
   specs:
-    bitfields (0.10.0)
+    bitfields (0.11.0)
+      activerecord (>= 5.1)
 
 GEM
   remote: https://rubygems.org/
@@ -57,4 +58,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/gemfiles/activerecord_5.2.gemfile.lock
+++ b/gemfiles/activerecord_5.2.gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: ..
   specs:
-    bitfields (0.10.0)
+    bitfields (0.11.0)
+      activerecord (>= 5.1)
 
 GEM
   remote: https://rubygems.org/
@@ -57,4 +58,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/lib/bitfields.rb
+++ b/lib/bitfields.rb
@@ -80,6 +80,16 @@ module Bitfields
     end
 
     def add_bitfield_methods(column, options)
+      if options[:added_instance_methods] != false
+        after_find do
+          if self.has_attribute?(column)
+            current_bitfields = bitfield_values(column)
+            current_bitfields.each(&method(:write_attribute))
+            clear_attribute_changes(current_bitfields.keys)
+          end
+        end
+      end
+
       bitfields[column].keys.each do |bit_name|
         if options[:added_instance_methods] != false
           attribute bit_name, :boolean, default: false

--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -190,84 +190,249 @@ describe Bitfields do
       user.bits.should == 7
     end
 
-    it "has _was" do
-      user = User.new
-      user.seller_was.should == false
-      user.seller = true
-      user.save!
-      user.seller_was.should == true
+    context "when instantiating a new record" do
+      it "has _was" do
+        user = User.new(:seller => true)
+        user.seller_was.should == false
+        user.save!
+        user.seller_was.should == true
+      end
+
+      it "has _changed?" do
+        user = User.new(:seller => true)
+        user.seller_changed?.should == true
+        user.save!
+        user.seller_changed?.should == false
+      end
+
+      it "has _change" do
+        user = User.new(:seller => true)
+        user.seller_change.should == [false, true]
+        user.save!
+        user.seller_change.should == nil
+        user.seller = false
+        user.seller_change.should == [true, false]
+      end
+
+      it "has _before_last_save" do
+        user = User.new(:seller => true)
+        user.seller_before_last_save.should == nil
+        user.save!
+        user.seller_before_last_save.should == false
+      end
+
+      it "has _change_to_be_saved" do
+        user = User.new(:seller => true)
+        user.seller_change_to_be_saved.should == [false, true]
+        user.save!
+        user.seller_change_to_be_saved.should == nil
+      end
+
+      it "has _in_database" do
+        user = User.new(:seller => true)
+        user.seller_in_database.should == false
+        user.save!
+        user.seller_in_database.should == true
+      end
+
+      it "has saved_change_to_" do
+        user = User.new(:seller => true)
+        user.saved_change_to_seller.should == nil
+        user.save!
+        user.saved_change_to_seller.should == [false, true]
+      end
+
+      it "has saved_change_to_?" do
+        user = User.new(:seller => true)
+        user.saved_change_to_seller?.should == false
+        user.save!
+        user.saved_change_to_seller?.should == true
+      end
+
+      it "has will_save_change_to_?" do
+        user = User.new(:seller => true)
+        user.will_save_change_to_seller?.should == true
+        user.save!
+        user.will_save_change_to_seller?.should == nil
+        user.seller = false
+        user.will_save_change_to_seller?.should == true
+      end
     end
 
-    it "has _changed?" do
-      user = User.new
-      user.seller_changed?.should == false
-      user.seller = true
-      user.seller_changed?.should == true
-      user.save!
-      user.seller_changed?.should == false
+    context "when creating a new model" do
+      it "has _was" do
+        user = User.create!(:seller => true)
+        user.seller = false
+        user.seller_was.should == true
+        user.save!
+        user.seller_was.should == false
+      end
+
+      it "has _changed?" do
+        user = User.create!(:seller => true)
+        user.seller_changed?.should == false
+        user.seller = false
+        user.seller_changed?.should == true
+        user.save!
+        user.seller_changed?.should == false
+      end
+
+      it "has _change" do
+        user = User.create!(:seller => true)
+        user.seller_change.should == nil
+        user.seller = false
+        user.seller_change.should == [true, false]
+        user.save!
+        user.seller_change.should == nil
+      end
+
+      it "has _before_last_save" do
+        user = User.create!(:seller => true)
+        user.seller_before_last_save.should == false
+        user.seller = false
+        user.save!
+        user.seller_before_last_save.should == true
+      end
+
+      it "has _change_to_be_saved" do
+        user = User.create!(:seller => true)
+        user.seller_change_to_be_saved.should == nil
+        user.seller = false
+        user.seller_change_to_be_saved.should == [true, false]
+        user.save!
+        user.seller_change_to_be_saved.should == nil
+      end
+
+      it "has _in_database" do
+        user = User.create!(:seller => true)
+        user.seller_in_database.should == true
+        user.seller = false
+        user.save!
+        user.seller_in_database.should == false
+      end
+
+      it "has saved_change_to_" do
+        user = User.create!(:seller => true)
+        user.saved_change_to_seller.should == [false, true]
+      end
+
+      it "has saved_change_to_?" do
+        user = User.create!(:seller => true)
+        user.saved_change_to_seller?.should == true
+      end
+
+      it "has will_save_change_to_?" do
+        user = User.create!(:seller => true)
+        user.will_save_change_to_seller?.should == nil
+        user.seller = false
+        user.will_save_change_to_seller?.should == true
+        user.save!
+        user.will_save_change_to_seller?.should == nil
+        user.seller = true
+        user.will_save_change_to_seller?.should == true
+      end
     end
 
-    it "has _change" do
-      user = User.new
-      user.seller_change.should == nil
-      user.seller = true
-      user.seller_change.should == [false, true]
-      user.save!
-      user.seller_change.should == nil
-    end
+    context "when loading a model from the database" do
+      it "has _was" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller
+        user.seller = false
+        user.seller_was.should == true
+        user.save!
+        user.seller_was.should == false
+      end
 
-    it "has _before_last_save" do
-      user = User.new
-      user.seller_before_last_save.should == nil
-      user.seller = true
-      user.save!
-      user.seller_before_last_save.should == false
-    end
+      it "has _changed?" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller_changed?.should == false
+        user.seller = false
+        user.seller_changed?.should == true
+        user.save!
+        user.seller_changed?.should == false
+      end
 
-    it "has _change_to_be_saved" do
-      user = User.new
-      user.seller_change_to_be_saved.should == nil
-      user.seller = true
-      user.seller_change_to_be_saved.should == [false, true]
-      user.save!
-      user.seller_change_to_be_saved.should == nil
-    end
+      it "has _change" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller_change.should == nil
+        user.seller = false
+        user.seller_change.should == [true, false]
+        user.save!
+        user.seller_change.should == nil
+      end
 
-    it "has _in_database" do
-      user = User.new
-      user.seller_in_database.should == false
-      user.seller = true
-      user.save!
-      user.seller_in_database.should == true
-    end
+      it "has _before_last_save" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller_before_last_save.should == nil
+        user.seller = false
+        user.save!
+        user.seller_before_last_save.should == true
+      end
 
-    it "has saved_change_to_" do
-      user = User.new
-      user.saved_change_to_seller.should == nil
-      user.seller = true
-      user.saved_change_to_seller.should == nil
-      user.save!
-      user.saved_change_to_seller.should == [false, true]
-    end
+      it "has _change_to_be_saved" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller_change_to_be_saved.should == nil
+        user.seller = false
+        user.seller_change_to_be_saved.should == [true, false]
+        user.save!
+        user.seller_change_to_be_saved.should == nil
+      end
 
-    it "has saved_change_to_?" do
-      user = User.new
-      user.saved_change_to_seller?.should == false
-      user.seller = true
-      user.saved_change_to_seller?.should == false
-      user.save!
-      user.saved_change_to_seller?.should == true
-    end
+      it "has _in_database" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller_in_database.should == true
+        user.seller = false
+        user.save!
+        user.seller_in_database.should == false
+      end
 
-    it "has will_save_change_to_?" do
-      user = User.new
-      user.will_save_change_to_seller?.should == nil
-      user.seller = true
-      user.will_save_change_to_seller?.should == true
-      user.save!
-      user.will_save_change_to_seller?.should == nil
-      user.seller = false
-      user.will_save_change_to_seller?.should == true
+      it "has saved_change_to_" do
+        User.create!(:seller => true)
+        user = User.last
+        user.saved_change_to_seller.should == nil
+        user.seller = false
+        user.saved_change_to_seller.should == nil
+        user.save!
+        user.saved_change_to_seller.should == [true, false]
+      end
+
+      it "has saved_change_to_?" do
+        User.create!(:seller => true)
+        user = User.last
+        user.saved_change_to_seller?.should == false
+        user.seller = false
+        user.saved_change_to_seller?.should == false
+        user.save!
+        user.saved_change_to_seller?.should == true
+      end
+
+      it "has will_save_change_to_?" do
+        User.create!(:seller => true)
+        user = User.last
+        user.will_save_change_to_seller?.should == nil
+        user.seller = false
+        user.will_save_change_to_seller?.should == true
+        user.save!
+        user.will_save_change_to_seller?.should == nil
+        user.seller = true
+        user.will_save_change_to_seller?.should == true
+      end
+
+      context "when the model loaded from the database does not select the bitfield column" do
+        it "does not try to assign the bitfield attributes" do
+          User.create!(:seller => true)
+
+          lambda{
+            User.select(:id).last
+          }.should_not raise_error
+        end
+      end
     end
 
     it "has _became_true?" do
@@ -299,6 +464,10 @@ describe Bitfields do
         describe "method #{meth} is not generated" do
           UserWithInstanceOptions.new.respond_to?(meth).should == false
         end
+      end
+
+      it "does not define an after_find method" do
+        UserWithInstanceOptions.new.respond_to?(:after_find).should == false
       end
     end
 


### PR DESCRIPTION
With the changes made in https://github.com/grosser/bitfields/pull/34, a bug was introduced that would cause bitfield attributes (for dirty tracking) to be incorrectly initialized when loading a model from the database.

```rb
class User < ActiveRecord::Base
  include Bitfields
  bitfield :bits, 1 => :foo
end

user = User.create!(:foo => true) 
# => #<User:0x007ff15b3e05e0 id: 1, bits: 1>
user.attributes 
# => {"id"=>1, "bits"=>1, "foo"=>true}

loaded_user = User.last
# => #<User:0x007ff15b3e05e0 id: 1, bits: 1>
loaded_user.attributes
# => {"id"=>1, "bits"=>1, "foo"=>false}
```

This occurs because when ActiveRecord loads a model from the database, it bypasses the standard initializer, and instead uses the [`instantiate`](https://api.rubyonrails.org/v5.1.7/classes/ActiveRecord/Persistence/ClassMethods.html#method-i-instantiate) method, which won't correctly populate the `attributes` hash that ActiveRecord uses for dirty tracking.

To address this issue, we decided to instead manually set each bitfield's current state when the model is loaded via a find using the `after_find` model callback. A few points to note about this solution:
- We are writing to the `attributes` hash using the `write_attribute` method. This will update the value _only_ within the `attributes` hash, so we don't need to worry about accidentally changing the bitfield's really value.
- Because we write a change to the `attributes` hash, it treats our update to the correct value as a change. Since we are trying to initialize the model, we make all the necessary changes and then tell the underlying mutation tracker to clear any changes that were made to the bitfields.
- Since models may potentially be loaded using a `.select` that may or may not include our bitfield's column, we have to check if the column itself is actually loaded on the instantiated model before attempting to set the bitfield values.