### PR TITLE
Remove Bitfields as Virtual Attributes and Replace with Manually Created Methods

### DIFF
--- a/gemfiles/activerecord_5.1.gemfile.lock
+++ b/gemfiles/activerecord_5.1.gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: ..
   specs:
-    bitfields (0.10.0)
+    bitfields (0.11.0)
+      activerecord (>= 5.1)
 
 GEM
   remote: https://rubygems.org/
@@ -57,4 +58,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/gemfiles/activerecord_5.2.gemfile.lock
+++ b/gemfiles/activerecord_5.2.gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: ..
   specs:
-    bitfields (0.10.0)
+    bitfields (0.11.0)
+      activerecord (>= 5.1)
 
 GEM
   remote: https://rubygems.org/
@@ -57,4 +58,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/lib/bitfields.rb
+++ b/lib/bitfields.rb
@@ -80,23 +80,21 @@ module Bitfields
     end
 
     def add_bitfield_methods(column, options)
-      if options[:added_instance_methods] != false
-        after_find do
-          if self.has_attribute?(column)
-            current_bitfields = bitfield_values(column)
-            current_bitfields.each(&method(:write_attribute))
-            clear_attribute_changes(current_bitfields.keys)
-          end
-        end
-      end
-
       bitfields[column].keys.each do |bit_name|
         if options[:added_instance_methods] != false
-          attribute bit_name, :boolean, default: false
-
           define_method(bit_name) { bitfield_value(bit_name) }
           define_method("#{bit_name}?") { bitfield_value(bit_name) }
-          define_method("#{bit_name}=") { |value| super(value); set_bitfield_value(bit_name, value) }
+          define_method("#{bit_name}=") { |value| set_bitfield_value(bit_name, value) }
+
+          # Dirty methods usable in before_save contexts
+          define_method("#{bit_name}_was") { bitfield_value_was(bit_name) }
+          alias_method "#{bit_name}_in_database", "#{bit_name}_was"
+
+          define_method("#{bit_name}_change") { bitfield_value_change(bit_name) }
+          alias_method "#{bit_name}_change_to_be_saved", "#{bit_name}_change"
+
+          define_method("#{bit_name}_changed?") { bitfield_value_change(bit_name).present? }
+          alias_method "will_save_change_to_#{bit_name}?", "#{bit_name}_changed?"
 
           define_method("#{bit_name}_became_true?") do
             value = bitfield_value(bit_name)
@@ -106,6 +104,11 @@ module Bitfields
             value = bitfield_value(bit_name)
             !value && send("#{bit_name}_was") != value
           end
+
+          # Dirty methods usable in after_save contexts
+          define_method("#{bit_name}_before_last_save") { bitfield_value_before_last_save(bit_name) }
+          define_method("saved_change_to_#{bit_name}") { saved_change_to_bitfield_value(bit_name) }
+          define_method("saved_change_to_#{bit_name}?") { saved_change_to_bitfield_value(bit_name).present? }
         end
 
         if options[:scopes] != false
@@ -194,6 +197,25 @@ module Bitfields
     def bitfield_value_was(bit_name)
       column, bit, _ = bitfield_info(bit_name)
       send("#{column}_was") & bit != 0
+    end
+
+    def bitfield_value_before_last_save(bit_name)
+      column, bit, _ = bitfield_info(bit_name)
+      column_before_last_save = send("#{column}_before_last_save")
+      column_before_last_save.nil? ? nil : column_before_last_save & bit != 0
+    end
+
+    def bitfield_value_change(bit_name)
+      values = [bitfield_value_was(bit_name), bitfield_value(bit_name)]
+      values unless values[0] == values[1]
+    end
+
+    def saved_change_to_bitfield_value(bit_name)
+      value_before_last_save = bitfield_value_before_last_save(bit_name)
+      current_value = bitfield_value(bit_name)
+      unless value_before_last_save.nil? || (value_before_last_save == current_value)
+        [value_before_last_save, current_value]
+      end
     end
 
     def set_bitfield_value(bit_name, value)

--- a/lib/bitfields.rb
+++ b/lib/bitfields.rb
@@ -80,6 +80,16 @@ module Bitfields
     end
 
     def add_bitfield_methods(column, options)
+      if options[:added_instance_methods] != false
+        after_find do
+          if self.has_attribute?(column)
+            current_bitfields = bitfield_values(column)
+            current_bitfields.each(&method(:write_attribute))
+            clear_attribute_changes(current_bitfields.keys)
+          end
+        end
+      end
+
       bitfields[column].keys.each do |bit_name|
         if options[:added_instance_methods] != false
           attribute bit_name, :boolean, default: false

--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -253,7 +253,7 @@ describe Bitfields do
         user = User.new(:seller => true)
         user.will_save_change_to_seller?.should == true
         user.save!
-        user.will_save_change_to_seller?.should == nil
+        user.will_save_change_to_seller?.should == false
         user.seller = false
         user.will_save_change_to_seller?.should == true
       end
@@ -323,11 +323,11 @@ describe Bitfields do
 
       it "has will_save_change_to_?" do
         user = User.create!(:seller => true)
-        user.will_save_change_to_seller?.should == nil
+        user.will_save_change_to_seller?.should == false
         user.seller = false
         user.will_save_change_to_seller?.should == true
         user.save!
-        user.will_save_change_to_seller?.should == nil
+        user.will_save_change_to_seller?.should == false
         user.seller = true
         user.will_save_change_to_seller?.should == true
       end
@@ -415,11 +415,11 @@ describe Bitfields do
       it "has will_save_change_to_?" do
         User.create!(:seller => true)
         user = User.last
-        user.will_save_change_to_seller?.should == nil
+        user.will_save_change_to_seller?.should == false
         user.seller = false
         user.will_save_change_to_seller?.should == true
         user.save!
-        user.will_save_change_to_seller?.should == nil
+        user.will_save_change_to_seller?.should == false
         user.seller = true
         user.will_save_change_to_seller?.should == true
       end
@@ -483,7 +483,7 @@ describe Bitfields do
 
     it "records a change when setting" do
       u = User.new(:seller => true)
-      u.changes.should == { 'bits' => [0,1], 'seller' => [false, true] }
+      u.changes.should == { 'bits' => [0,1] }
       u.bitfield_changes.should == {'seller' => [false, true]}
     end
   end

--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -190,84 +190,249 @@ describe Bitfields do
       user.bits.should == 7
     end
 
-    it "has _was" do
-      user = User.new
-      user.seller_was.should == false
-      user.seller = true
-      user.save!
-      user.seller_was.should == true
+    context "when instantiating a new record" do
+      it "has _was" do
+        user = User.new(:seller => true)
+        user.seller_was.should == false
+        user.save!
+        user.seller_was.should == true
+      end
+
+      it "has _changed?" do
+        user = User.new(:seller => true)
+        user.seller_changed?.should == true
+        user.save!
+        user.seller_changed?.should == false
+      end
+
+      it "has _change" do
+        user = User.new(:seller => true)
+        user.seller_change.should == [false, true]
+        user.save!
+        user.seller_change.should == nil
+        user.seller = false
+        user.seller_change.should == [true, false]
+      end
+
+      it "has _before_last_save" do
+        user = User.new(:seller => true)
+        user.seller_before_last_save.should == nil
+        user.save!
+        user.seller_before_last_save.should == false
+      end
+
+      it "has _change_to_be_saved" do
+        user = User.new(:seller => true)
+        user.seller_change_to_be_saved.should == [false, true]
+        user.save!
+        user.seller_change_to_be_saved.should == nil
+      end
+
+      it "has _in_database" do
+        user = User.new(:seller => true)
+        user.seller_in_database.should == false
+        user.save!
+        user.seller_in_database.should == true
+      end
+
+      it "has saved_change_to_" do
+        user = User.new(:seller => true)
+        user.saved_change_to_seller.should == nil
+        user.save!
+        user.saved_change_to_seller.should == [false, true]
+      end
+
+      it "has saved_change_to_?" do
+        user = User.new(:seller => true)
+        user.saved_change_to_seller?.should == false
+        user.save!
+        user.saved_change_to_seller?.should == true
+      end
+
+      it "has will_save_change_to_?" do
+        user = User.new(:seller => true)
+        user.will_save_change_to_seller?.should == true
+        user.save!
+        user.will_save_change_to_seller?.should == nil
+        user.seller = false
+        user.will_save_change_to_seller?.should == true
+      end
     end
 
-    it "has _changed?" do
-      user = User.new
-      user.seller_changed?.should == false
-      user.seller = true
-      user.seller_changed?.should == true
-      user.save!
-      user.seller_changed?.should == false
+    context "when creating a new model" do
+      it "has _was" do
+        user = User.create!(:seller => true)
+        user.seller = false
+        user.seller_was.should == true
+        user.save!
+        user.seller_was.should == false
+      end
+
+      it "has _changed?" do
+        user = User.create!(:seller => true)
+        user.seller_changed?.should == false
+        user.seller = false
+        user.seller_changed?.should == true
+        user.save!
+        user.seller_changed?.should == false
+      end
+
+      it "has _change" do
+        user = User.create!(:seller => true)
+        user.seller_change.should == nil
+        user.seller = false
+        user.seller_change.should == [true, false]
+        user.save!
+        user.seller_change.should == nil
+      end
+
+      it "has _before_last_save" do
+        user = User.create!(:seller => true)
+        user.seller_before_last_save.should == false
+        user.seller = false
+        user.save!
+        user.seller_before_last_save.should == true
+      end
+
+      it "has _change_to_be_saved" do
+        user = User.create!(:seller => true)
+        user.seller_change_to_be_saved.should == nil
+        user.seller = false
+        user.seller_change_to_be_saved.should == [true, false]
+        user.save!
+        user.seller_change_to_be_saved.should == nil
+      end
+
+      it "has _in_database" do
+        user = User.create!(:seller => true)
+        user.seller_in_database.should == true
+        user.seller = false
+        user.save!
+        user.seller_in_database.should == false
+      end
+
+      it "has saved_change_to_" do
+        user = User.create!(:seller => true)
+        user.saved_change_to_seller.should == [false, true]
+      end
+
+      it "has saved_change_to_?" do
+        user = User.create!(:seller => true)
+        user.saved_change_to_seller?.should == true
+      end
+
+      it "has will_save_change_to_?" do
+        user = User.create!(:seller => true)
+        user.will_save_change_to_seller?.should == nil
+        user.seller = false
+        user.will_save_change_to_seller?.should == true
+        user.save!
+        user.will_save_change_to_seller?.should == nil
+        user.seller = true
+        user.will_save_change_to_seller?.should == true
+      end
     end
 
-    it "has _change" do
-      user = User.new
-      user.seller_change.should == nil
-      user.seller = true
-      user.seller_change.should == [false, true]
-      user.save!
-      user.seller_change.should == nil
-    end
+    context "when loading a model from the database" do
+      it "has _was" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller
+        user.seller = false
+        user.seller_was.should == true
+        user.save!
+        user.seller_was.should == false
+      end
 
-    it "has _before_last_save" do
-      user = User.new
-      user.seller_before_last_save.should == nil
-      user.seller = true
-      user.save!
-      user.seller_before_last_save.should == false
-    end
+      it "has _changed?" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller_changed?.should == false
+        user.seller = false
+        user.seller_changed?.should == true
+        user.save!
+        user.seller_changed?.should == false
+      end
 
-    it "has _change_to_be_saved" do
-      user = User.new
-      user.seller_change_to_be_saved.should == nil
-      user.seller = true
-      user.seller_change_to_be_saved.should == [false, true]
-      user.save!
-      user.seller_change_to_be_saved.should == nil
-    end
+      it "has _change" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller_change.should == nil
+        user.seller = false
+        user.seller_change.should == [true, false]
+        user.save!
+        user.seller_change.should == nil
+      end
 
-    it "has _in_database" do
-      user = User.new
-      user.seller_in_database.should == false
-      user.seller = true
-      user.save!
-      user.seller_in_database.should == true
-    end
+      it "has _before_last_save" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller_before_last_save.should == nil
+        user.seller = false
+        user.save!
+        user.seller_before_last_save.should == true
+      end
 
-    it "has saved_change_to_" do
-      user = User.new
-      user.saved_change_to_seller.should == nil
-      user.seller = true
-      user.saved_change_to_seller.should == nil
-      user.save!
-      user.saved_change_to_seller.should == [false, true]
-    end
+      it "has _change_to_be_saved" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller_change_to_be_saved.should == nil
+        user.seller = false
+        user.seller_change_to_be_saved.should == [true, false]
+        user.save!
+        user.seller_change_to_be_saved.should == nil
+      end
 
-    it "has saved_change_to_?" do
-      user = User.new
-      user.saved_change_to_seller?.should == false
-      user.seller = true
-      user.saved_change_to_seller?.should == false
-      user.save!
-      user.saved_change_to_seller?.should == true
-    end
+      it "has _in_database" do
+        User.create!(:seller => true)
+        user = User.last
+        user.seller_in_database.should == true
+        user.seller = false
+        user.save!
+        user.seller_in_database.should == false
+      end
 
-    it "has will_save_change_to_?" do
-      user = User.new
-      user.will_save_change_to_seller?.should == nil
-      user.seller = true
-      user.will_save_change_to_seller?.should == true
-      user.save!
-      user.will_save_change_to_seller?.should == nil
-      user.seller = false
-      user.will_save_change_to_seller?.should == true
+      it "has saved_change_to_" do
+        User.create!(:seller => true)
+        user = User.last
+        user.saved_change_to_seller.should == nil
+        user.seller = false
+        user.saved_change_to_seller.should == nil
+        user.save!
+        user.saved_change_to_seller.should == [true, false]
+      end
+
+      it "has saved_change_to_?" do
+        User.create!(:seller => true)
+        user = User.last
+        user.saved_change_to_seller?.should == false
+        user.seller = false
+        user.saved_change_to_seller?.should == false
+        user.save!
+        user.saved_change_to_seller?.should == true
+      end
+
+      it "has will_save_change_to_?" do
+        User.create!(:seller => true)
+        user = User.last
+        user.will_save_change_to_seller?.should == nil
+        user.seller = false
+        user.will_save_change_to_seller?.should == true
+        user.save!
+        user.will_save_change_to_seller?.should == nil
+        user.seller = true
+        user.will_save_change_to_seller?.should == true
+      end
+
+      context "when the model loaded from the database does not select the bitfield column" do
+        it "does not try to assign the bitfield attributes" do
+          User.create!(:seller => true)
+
+          lambda{
+            User.select(:id).last
+          }.should_not raise_error
+        end
+      end
     end
 
     it "has _became_true?" do
@@ -299,6 +464,10 @@ describe Bitfields do
         describe "method #{meth} is not generated" do
           UserWithInstanceOptions.new.respond_to?(meth).should == false
         end
+      end
+
+      it "does not define an after_find method" do
+        UserWithInstanceOptions.new.respond_to?(:after_find).should == false
       end
     end
 


### PR DESCRIPTION
In performing some more extensive testing on our previous approach (https://github.com/grosser/bitfields/pull/35) we discovered that the drawbacks, primarily performance in ensuring attributes were set correctly after a find, wasn't scalable. In response, we decided to instead move back to the initial implementation with explicitly defined "dirty" methods for each bitfield, and add in the new Rails 5.1+ specific ones. 

As noted within the readme, Rails 5.1+ introduces a more methods that are intended to be called within certain points of a model's lifecycle. Previously existing methods, `xxx_was` and `xxx_changed` for example, are intended to be used _only_ before a model has been saved, including `before_xxx` callbacks within the model. The new methods, `xxx_before_last_save`, `saved_change_to_xxx?`, etc., are to be used within after the model has been saved.

One of the major drawbacks of this change is that we are no longer able to utilize the generic "dirty" methods that take an attribute as an argument (e.g. `attribute_before_last_save(:attribute)`). In upgrading our application's version of Rails, we were utilizing this behavior as a means of maintaining consistent and backwards compatible changes. We investigated overriding each generic method and inspecting if the passed attribute was one of the bitfields and invoking the corresponding "dirty" method, but this felt like a code smell. As such, we decided against pursuing it further.