### PR TITLE
bit_operator_or works wrong for false bits

### DIFF
--- a/lib/bitfields.rb
+++ b/lib/bitfields.rb
@@ -143,7 +143,8 @@ module Bitfields
         result = []
         bit_values.each do |bit_name, value|
           bit = bitfields[column][bit_name]
-          result << "(#{table_name}.#{column} & #{bit}) = #{bit}" if value
+          eql = value ? bit : 0
+          result << "(#{table_name}.#{column} & #{bit}) = #{eql}"
         end
         result.join(' OR ')
       else raise("bitfields: unknown query mode #{mode.inspect}")

--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -539,7 +539,7 @@ describe Bitfields do
 
     describe 'with OR' do
       it "generates sql for each bit" do
-        User.bitfield_sql({:seller => true, :insane => true}, :query_mode => :bit_operator_or).should == '(users.bits & 1) = 1 OR (users.bits & 2) = 2'
+        User.bitfield_sql({:seller => true, :insane => true, :stupid => false}, :query_mode => :bit_operator_or).should == '(users.bits & 1) = 1 OR (users.bits & 2) = 2 OR (users.bits & 4) = 0'
       end
 
       it "generates working sql" do

--- a/spec/bitfields_spec.rb
+++ b/spec/bitfields_spec.rb
@@ -547,8 +547,14 @@ describe Bitfields do
         u2 = User.create!(:seller => true, :insane => false)
         u3 = User.create!(:seller => false, :insane => false)
 
-        conditions = User.bitfield_sql({:seller => true, :insane => false}, :query_mode => :bit_operator_or)
+        conditions = User.bitfield_sql({:seller => true, :insane => true}, :query_mode => :bit_operator_or)
         User.where(conditions).should == [u1, u2]
+
+        conditions = User.bitfield_sql({:seller => true, :insane => false}, :query_mode => :bit_operator_or)
+        User.where(conditions).should == [u1, u2, u3]
+
+        conditions = User.bitfield_sql({:seller => false, :insane => false}, :query_mode => :bit_operator_or)
+        User.where(conditions).should == [u2, u3]
       end
     end
 


### PR DESCRIPTION
update specs to compare bitfield_sql(:query_mode => :bit_operator_or) behavior with database booleans

Currently it ignore false bits, but if use database boolean it compare with false.

I have solution, and will push it after you confirm that my suggestion is right. Not do it now, to show errors in CI