### PR TITLE
optimize bit_operator_or by checking all bits at once

### DIFF
--- a/lib/bitfields.rb
+++ b/lib/bitfields.rb
@@ -140,12 +140,10 @@ module Bitfields
         on, off = bit_values_to_on_off(column, bit_values)
         "(#{table_name}.#{column} & #{on+off}) = #{on}"
       when :bit_operator_or
+        on, off = bit_values_to_on_off(column, bit_values)
         result = []
-        bit_values.each do |bit_name, value|
-          bit = bitfields[column][bit_name]
-          eql = value ? bit : 0
-          result << "(#{table_name}.#{column} & #{bit}) = #{eql}"
-        end
+        result << "(#{table_name}.#{column} & #{on}) <> 0" if on != 0
+        result << "(#{table_name}.#{column} & #{off}) <> #{off}" if off != 0
         result.join(' OR ')
       else raise("bitfields: unknown query mode #{mode.inspect}")
       end


### PR DESCRIPTION
instead of checking each bit individually

I group bits by ON and OFF and check it separately. So in worst case, where we need compare ON and OFF bit, we will have 2 statements and one OR operation

For ON bits, idea that if any of bits on both sides is ON, then we will have non zero value.
e.g. 0100 is column value, and we check that any of bits is true
```0100 & 1111 <> 0000```

For OFF bits, where OFF bits impressed with '1', like ```bit_values_to_on_off``` returns it. If any of column bits OFF compared value, then compared will be different. 
e.g. 1011 is column value, and we check that any of bits is false
```1011 & 1111 <> 1111```


